### PR TITLE
Add some constants so you can use indetermiante progress mode without de...

### DIFF
--- a/library/src/main/java/com/dd/CircularProgressButton.java
+++ b/library/src/main/java/com/dd/CircularProgressButton.java
@@ -474,7 +474,7 @@ public class CircularProgressButton extends Button {
     private OnAnimationEndListener mErrorStateListener = new OnAnimationEndListener() {
         @Override
         public void onAnimationEnd() {
-            if (mIconComplete != 0) {
+            if (mIconError != 0) {
                 setText(null);
                 setIcon(mIconError);
             } else {


### PR DESCRIPTION
...fining your own constants

Use stable constants so we don't have to constantly define them anymore.

This also fixes the bug in #40, you should be able to allow an error icon without setting the complete icon.
