### PR TITLE
Added Proguad config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ dependencies {
 }
 ```
 
+### ProGuard
+
+If you are using proguard with your project, add following code to your proguard config file
+
+```
+-keepclassmembers class com.dd.StrokeGradientDrawable {
+    public void setStrokeColor(int);
+}
+```
+
 ### Contributions
 
 If you want to contribute to this library make sure you send pull request to **dev** branch.


### PR DESCRIPTION
I have been using this library a lot lately. It works really well. But when I use proguard, the drawable seems a bit off. And it shows that `setStrokeColor` method not found. This change fixed it.

ProGuard Enabled without keeping setStrokColor
![circ1](https://cloud.githubusercontent.com/assets/1256649/7630085/47258cc6-fa50-11e4-8798-478695e36192.png)

ProGuard Enabled with keep setStrokeColor
![circ2](https://cloud.githubusercontent.com/assets/1256649/7630099/735c640e-fa50-11e4-92ee-8854d919722a.png)
